### PR TITLE
Adding mock package 5_8_0_Test.pm for 5_8_0.pm

### DIFF
--- a/lib/GRNOC/NetConf/Device/Brocade/MLXe/5_8_0.pm
+++ b/lib/GRNOC/NetConf/Device/Brocade/MLXe/5_8_0.pm
@@ -6,6 +6,7 @@ use strict;
 use warnings;
 
 use Moo;
+use GRNOC::Log;
 use XML::Writer;
 use XML::Simple;
 
@@ -13,7 +14,7 @@ has logger => (is => 'rwp');
 has ssh => (is => 'rwp');
 has chan => (is => 'rwp');
 has msg_id => (is => 'rwp');
-
+has auto_connect => (is => 'rwp', default => 1);
 
 use constant NETCONF => "urn:ietf:params:xml:ns:netconf:base:1.0";
 use constant BROCADE => "http://brocade.com/ns/netconf/config/netiron-config/";
@@ -27,7 +28,9 @@ sub BUILD{
     my $logger = GRNOC::Log->get_logger("GRNOC::NetConf::Device::Brocade::MLXe::5_8_0");
     $self->_set_logger($logger);
 
-    $self->_connect();
+    if ($self->auto_connect == 1) {
+        $self->_connect();
+    }
     $self->_set_msg_id(0);
 
     return $self;
@@ -43,7 +46,6 @@ sub _connect{
     my $subsystem = $self->chan->subsystem('netconf');
     
     $self->do_handshake();
-
 }
 
 sub _get_msg_id{

--- a/lib/GRNOC/NetConf/Device/Brocade/MLXe/5_8_0_Test.pm
+++ b/lib/GRNOC/NetConf/Device/Brocade/MLXe/5_8_0_Test.pm
@@ -1,0 +1,45 @@
+#!/usr/bin/perl
+
+package GRNOC::NetConf::Device::Brocade::MLXe::5_8_0_Test;
+
+use strict;
+use warnings;
+
+use Moo;
+use AnyEvent;
+use XML::Writer;
+use XML::Simple;
+
+extends 'GRNOC::NetConf::Device::Brocade::MLXe::5_8_0';
+
+has responseChan => (is => 'rwp');
+
+=head2 send
+
+Overrides the default send method that would otherwise send the
+request over SSH.
+
+=cut
+sub send {
+    my $self    = shift;
+    my $payload = shift;
+
+    $self->_set_responseChan(AnyEvent->condvar);
+    $self->responseChan->send($payload);
+}
+
+=head2 recv
+
+Overrides the default recv method that would otherwise receive the
+request over SSH.
+
+=cut
+sub recv {
+    my $self   = shift;
+
+    my $chan   = $self->responseChan;
+    my $string = $chan->recv();
+    return $string;
+}
+
+1;

--- a/lib/GRNOC/NetConf/Device/Brocade/MLXe/5_8_0_Test.pm
+++ b/lib/GRNOC/NetConf/Device/Brocade/MLXe/5_8_0_Test.pm
@@ -39,7 +39,10 @@ sub recv {
 
     my $chan   = $self->responseChan;
     my $string = $chan->recv();
-    return $string;
+
+    my $parser = XML::Simple->new();
+    my $xml    = $parser->XMLin($string);
+    return $xml;
 }
 
 1;

--- a/t/TEST
+++ b/t/TEST
@@ -33,7 +33,7 @@ if (defined $ENV{'TEST_FILES'}){
     }
 }
 else {
-    @tests = (<t/*.t>);
+    @tests = split(/\n/, `find t -type f | grep -v ".svn" | grep -v "~" | grep .t`);
 }
 
 if ($formatter) {

--- a/t/do_handshake.t
+++ b/t/do_handshake.t
@@ -1,0 +1,26 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+
+use Data::Dumper;
+use GRNOC::NetConf::Device::Brocade::MLXe::5_8_0_Test;
+use Test::More tests => 1;
+
+
+my $device;
+$device = GRNOC::NetConf::Device::Brocade::MLXe::5_8_0_Test->new( host => '127.0.0.1',
+                                                                  port => 22,
+                                                                  username => '',
+                                                                  password => '',
+                                                                  type => 'PC',
+                                                                  model => 'notta',
+                                                                  version => '0.0.0',
+                                                                  auto_connect => 0 );
+
+my $response;
+
+$response = $device->do_handshake();
+ok($response == 1, "Device completed handshake.");


### PR DESCRIPTION
The 5_8_0_Test package inherits from 5_8_0.pm. This package emulates a
connected device by overriding the underlying send and recv methods. This
allows us to verify that the other methods of 5_8_0 handle expected
and unexpected responses correctly.